### PR TITLE
Fix: Set the scrape manager

### DIFF
--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -77,6 +77,7 @@ func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, walDir string
 		flushDeadline:     flushDeadline,
 		samplesIn:         newEWMARate(ewmaWeight, shardUpdateDuration),
 		walDir:            walDir,
+		scraper:           sm,
 	}
 	go rws.run()
 	return rws


### PR DESCRIPTION
I completely missed this in my original PR. I believe I lost it on my last rebase from master to FF my original branch.

I'm a bit surprised that `gofmt` didn't yell at something like this. As for a test, I couldn't come up with a good test to ensure this does not happen again other than setting it and then ensure it is there - but that seems unnecessary? Opinions are welcome.