### PR TITLE
Merge feat-expose-rw-client to 2.25.0

### DIFF
--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -100,7 +100,7 @@ func TestSampleDelivery(t *testing.T) {
 	require.NoError(t, s.ApplyConfig(conf))
 	hash, err := toHash(writeConfig)
 	require.NoError(t, err)
-	qm := s.rws.queues[hash]
+	qm := s.Write.queues[hash]
 	qm.SetClient(c)
 
 	qm.StoreSeries(series, 0)

--- a/storage/remote/read_test.go
+++ b/storage/remote/read_test.go
@@ -101,7 +101,7 @@ func TestNoDuplicateReadConfigs(t *testing.T) {
 				RemoteReadConfigs: tc.cfgs,
 			}
 			err := s.ApplyConfig(conf)
-			prometheus.Unregister(s.rws.highestTimestamp)
+			prometheus.Unregister(s.Write.highestTimestamp)
 			gotError := err != nil
 			require.Equal(t, tc.err, gotError)
 			require.NoError(t, s.Close())

--- a/storage/remote/storage_test.go
+++ b/storage/remote/storage_test.go
@@ -55,7 +55,7 @@ func TestStorageLifecycle(t *testing.T) {
 	require.NoError(t, s.ApplyConfig(conf))
 
 	// make sure remote write has a queue.
-	require.Equal(t, 1, len(s.rws.queues))
+	require.Equal(t, 1, len(s.Write.queues))
 
 	// make sure remote write has a queue.
 	require.Equal(t, 1, len(s.queryables))

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -56,7 +56,14 @@ type WriteStorage struct {
 
 	// For timestampTracker.
 	highestTimestamp *maxTimestamp
+
+	// NewClient defaults to NewWriteClient when creating WriteStorage.
+	NewClient WriteClientFunc
 }
+
+// WriteClientFunc returns a WriteClient given the name of a remote write
+// config. NewWriteClient implements the signature of this function.
+type WriteClientFunc func(name string, conf *ClientConfig) (WriteClient, error)
 
 // NewWriteStorage creates and runs a WriteStorage.
 func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, walDir string, flushDeadline time.Duration, sm ReadyScrapeManager) *WriteStorage {
@@ -82,6 +89,7 @@ func NewWriteStorage(logger log.Logger, reg prometheus.Registerer, walDir string
 				Help:      "Highest timestamp that has come into the remote storage via the Appender interface, in seconds since epoch.",
 			}),
 		},
+		NewClient: NewWriteClient,
 	}
 	if reg != nil {
 		reg.MustRegister(rws.highestTimestamp)
@@ -130,7 +138,7 @@ func (rws *WriteStorage) ApplyConfig(conf *config.Config) error {
 			name = rwConf.Name
 		}
 
-		c, err := NewWriteClient(name, &ClientConfig{
+		c, err := rws.NewClient(name, &ClientConfig{
 			URL:              rwConf.URL,
 			Timeout:          rwConf.RemoteTimeout,
 			HTTPClientConfig: rwConf.HTTPClientConfig,


### PR DESCRIPTION
Signed-off-by: Robert Fratto <robertfratto@gmail.com>

<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->