### PR TITLE
Shared interner: fix leak of interned strings from scrape cache

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -275,7 +275,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed 
 		// Update the targets retrieval function for metadata to a new scrape cache.
 		cache := opts.cache
 		if cache == nil {
-			cache = newScrapeCache()
+			cache = newScrapeCache(intern.Global)
 		}
 		opts.target.SetMetadataStore(cache)
 
@@ -396,7 +396,7 @@ func (sp *scrapePool) reload(cfg *config.ScrapeConfig) error {
 			oldLoop.disableEndOfRunStalenessMarkers()
 			cache = oc
 		} else {
-			cache = newScrapeCache()
+			cache = newScrapeCache(intern.Global)
 		}
 		var (
 			t       = sp.activeTargets[fp]
@@ -802,14 +802,16 @@ type scrapeCache struct {
 	// string in addDropped().
 	droppedSeries map[string]*uint64
 
-	// seriesCur and seriesPrev store the labels of series that were seen
-	// in the current and previous scrape.
+	// seriesCur and seriesPrev store the ref of series that were seen
+	// in the current and previous scrape based on the hash.
 	// We hold two maps and swap them out to save allocations.
-	seriesCur  map[uint64]labels.Labels
-	seriesPrev map[uint64]labels.Labels
+	seriesCur  map[uint64]*cacheEntry
+	seriesPrev map[uint64]*cacheEntry
 
 	metaMtx  sync.Mutex
 	metadata map[string]*metaEntry
+
+	interner intern.Interner
 }
 
 // metaEntry holds meta information about a metric.
@@ -825,13 +827,17 @@ func (m *metaEntry) size() int {
 	return len(m.help) + len(m.unit) + len(m.typ)
 }
 
-func newScrapeCache() *scrapeCache {
+func newScrapeCache(interner intern.Interner) *scrapeCache {
+	if interner == nil {
+		interner = intern.Global
+	}
 	return &scrapeCache{
 		series:        map[string]*cacheEntry{},
 		droppedSeries: map[string]*uint64{},
-		seriesCur:     map[uint64]labels.Labels{},
-		seriesPrev:    map[uint64]labels.Labels{},
+		seriesCur:     map[uint64]*cacheEntry{},
+		seriesPrev:    map[uint64]*cacheEntry{},
 		metadata:      map[string]*metaEntry{},
+		interner:      interner,
 	}
 }
 
@@ -858,7 +864,7 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 		// that haven't appeared in the last scrape.
 		for s, e := range c.series {
 			if c.iter != e.lastIter {
-				intern.ReleaseLabels(intern.Global, e.lset)
+				intern.ReleaseLabels(c.interner, e.lset)
 				delete(c.series, s)
 			}
 		}
@@ -883,8 +889,7 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	c.seriesPrev, c.seriesCur = c.seriesCur, c.seriesPrev
 
 	// We have to delete every single key in the map.
-	for k, lset := range c.seriesCur {
-		intern.ReleaseLabels(intern.Global, lset)
+	for k := range c.seriesCur {
 		delete(c.seriesCur, k)
 	}
 }
@@ -898,12 +903,14 @@ func (c *scrapeCache) get(met string) (*cacheEntry, bool) {
 	return e, true
 }
 
-func (c *scrapeCache) addRef(met string, ref uint64, lset labels.Labels, hash uint64) {
-	if ref == 0 {
-		return
-	}
-	intern.InternLabels(intern.Global, lset)
-	c.series[met] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
+func (c *scrapeCache) addRef(met string, ref uint64, lset labels.Labels, hash uint64) *cacheEntry {
+	// The cache entries are used for staleness tracking so even if ref is
+	// 0 we need to track it.
+	intern.InternLabels(c.interner, lset)
+
+	ce := &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
+	c.series[met] = ce
+	return ce
 }
 
 func (c *scrapeCache) addDropped(met string) {
@@ -919,15 +926,14 @@ func (c *scrapeCache) getDropped(met string) bool {
 	return ok
 }
 
-func (c *scrapeCache) trackStaleness(hash uint64, lset labels.Labels) {
-	intern.InternLabels(intern.Global, lset)
-	c.seriesCur[hash] = lset
+func (c *scrapeCache) trackStaleness(ce *cacheEntry) {
+	c.seriesCur[ce.hash] = ce
 }
 
 func (c *scrapeCache) forEachStale(f func(labels.Labels) bool) {
-	for h, lset := range c.seriesPrev {
-		if _, ok := c.seriesCur[h]; !ok {
-			if !f(lset) {
+	for hash, ce := range c.seriesPrev {
+		if _, ok := c.seriesCur[hash]; !ok {
+			if !f(ce.lset) {
 				break
 			}
 		}
@@ -1051,7 +1057,7 @@ func newScrapeLoop(ctx context.Context,
 		buffers = pool.New(1e3, 1e6, 3, func(sz int) interface{} { return make([]byte, 0, sz) })
 	}
 	if cache == nil {
-		cache = newScrapeCache()
+		cache = newScrapeCache(intern.Global)
 	}
 	sl := &scrapeLoop{
 		scraper:             sc,
@@ -1434,14 +1440,17 @@ loop:
 		}
 
 		if !ok {
+			ce := sl.cache.addRef(mets, ref, lset, hash)
 			if tp == nil {
 				// Bypass staleness logic if there is an explicit timestamp.
-				sl.cache.trackStaleness(hash, lset)
+				sl.cache.trackStaleness(ce)
 			}
-			sl.cache.addRef(mets, ref, lset, hash)
 			if sampleAdded && sampleLimitErr == nil {
 				seriesAdded++
 			}
+		} else if ce.ref != ref {
+			// Update the ref if it was invalidated.
+			ce.ref = ref
 		}
 
 		// Increment added even if there's an error so we correctly report the
@@ -1506,7 +1515,7 @@ func (sl *scrapeLoop) checkAddError(ce *cacheEntry, met []byte, tp *int64, err e
 	switch errors.Cause(err) {
 	case nil:
 		if tp == nil && ce != nil {
-			sl.cache.trackStaleness(ce.hash, ce.lset)
+			sl.cache.trackStaleness(ce)
 		}
 		return true, nil
 	case storage.ErrNotFound:

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -883,7 +883,8 @@ func (c *scrapeCache) iterDone(flushCache bool) {
 	c.seriesPrev, c.seriesCur = c.seriesCur, c.seriesPrev
 
 	// We have to delete every single key in the map.
-	for k := range c.seriesCur {
+	for k, lset := range c.seriesCur {
+		intern.ReleaseLabels(intern.Global, lset)
 		delete(c.seriesCur, k)
 	}
 }
@@ -901,6 +902,7 @@ func (c *scrapeCache) addRef(met string, ref uint64, lset labels.Labels, hash ui
 	if ref == 0 {
 		return
 	}
+	intern.InternLabels(intern.Global, lset)
 	c.series[met] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
 }
 
@@ -918,6 +920,7 @@ func (c *scrapeCache) getDropped(met string) bool {
 }
 
 func (c *scrapeCache) trackStaleness(hash uint64, lset labels.Labels) {
+	intern.InternLabels(intern.Global, lset)
 	c.seriesCur[hash] = lset
 }
 
@@ -1421,7 +1424,6 @@ loop:
 			}
 		}
 
-		intern.InternLabels(intern.Global, lset)
 		ref, err = app.Append(ref, lset, t, v)
 		sampleAdded, err = sl.checkAddError(ce, met, tp, err, &sampleLimitErr, &appErrs)
 		if err != nil {
@@ -1630,7 +1632,6 @@ func (sl *scrapeLoop) addReportSample(app storage.Appender, s string, t int64, v
 	switch errors.Cause(err) {
 	case nil:
 		if !ok {
-			intern.InternLabels(intern.Global, lset)
 			sl.cache.addRef(s, ref, lset, lset.Hash())
 		}
 		return nil

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -30,14 +31,17 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/pkg/exemplar"
+	"github.com/prometheus/prometheus/pkg/intern"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/relabel"
 	"github.com/prometheus/prometheus/pkg/textparse"
@@ -847,7 +851,7 @@ func TestScrapeLoopMetadata(t *testing.T) {
 	var (
 		signal  = make(chan struct{})
 		scraper = &testScraper{}
-		cache   = newScrapeCache()
+		cache   = newScrapeCache(intern.Global)
 	)
 	defer close(signal)
 
@@ -2558,4 +2562,219 @@ func TestScrapeLoopLabelLimit(t *testing.T) {
 			require.NoError(t, slApp.Commit())
 		}
 	}
+}
+
+func TestScrapeLoopCache_Interner(t *testing.T) {
+	var (
+		signal   = make(chan struct{})
+		interner = &testInterner{refs: map[string]int{}}
+		scraper  = &testScraper{}
+		cache    = newScrapeCache(interner)
+	)
+	defer close(signal)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sl := newScrapeLoop(ctx,
+		scraper,
+		nil, nil,
+		nopMutator,
+		nopMutator,
+		func(ctx context.Context) storage.Appender { return &collectResultAppender{} },
+		cache,
+		0,
+		true,
+		nil,
+	)
+	defer cancel()
+
+	slApp := sl.appender(ctx)
+
+	tt := []struct {
+		scrapeText string
+		expectRefs map[string]int
+	}{
+		{
+			scrapeText: `# TYPE first_metric counter
+# UNIT first_metric metric
+first_metric{first_label="first_value"} 1
+# TYPE second_metric counter
+# UNIT second_metric metric
+second_metric{second_label="second_value"} 1
+# EOF`,
+			expectRefs: map[string]int{
+				"first_metric":  1,
+				"first_label":   1,
+				"first_value":   1,
+				"second_metric": 1,
+				"second_label":  1,
+				"second_value":  1,
+			},
+		},
+		// Same scrape, ensre refs don't change
+		{
+			scrapeText: `# TYPE first_metric counter
+# UNIT first_metric metric
+first_metric{first_label="first_value"} 1
+# TYPE second_metric counter
+# UNIT second_metric metric
+second_metric{second_label="second_value"} 1
+# EOF`,
+			expectRefs: map[string]int{
+				"first_metric":  1,
+				"first_label":   1,
+				"first_value":   1,
+				"second_metric": 1,
+				"second_label":  1,
+				"second_value":  1,
+			},
+		},
+		// Remove a series, ensuring that their refs go to 0.
+		{
+			scrapeText: `# TYPE first_metric counter
+# UNIT first_metric metric
+first_metric{first_label="first_value"} 1
+# EOF`,
+			expectRefs: map[string]int{
+				"first_metric":  1,
+				"first_label":   1,
+				"first_value":   1,
+				"second_metric": 0,
+				"second_label":  0,
+				"second_value":  0,
+			},
+		},
+		// Add a label, ensuring that refs are mutated.
+		{
+			scrapeText: `# TYPE first_metric counter
+# UNIT first_metric metric
+first_metric{first_label="first_value",second_label="second_value"} 1
+# EOF`,
+			expectRefs: map[string]int{
+				"first_metric": 1,
+				"first_label":  1,
+				"first_value":  1,
+				"second_label": 1,
+				"second_value": 1,
+			},
+		},
+		// Remove everything.
+		{
+			scrapeText: `# EOF`,
+			expectRefs: map[string]int{
+				"first_metric": 0,
+				"first_label":  0,
+				"first_value":  0,
+				"second_label": 0,
+				"second_value": 0,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		_, _, _, err := sl.append(slApp, []byte(tc.scrapeText), "application/openmetrics-text", time.Now())
+		require.NoError(t, err)
+		require.NoError(t, slApp.Commit())
+
+		for k, expect := range tc.expectRefs {
+			require.Equal(t, expect, interner.refs[k], "%s must have %d references", k, expect)
+		}
+	}
+
+	fmt.Printf("interns: %d, releases: %d\n", interner.interns, interner.releases)
+}
+
+type testInterner struct {
+	intern.Interner
+
+	mut  sync.Mutex
+	refs map[string]int
+
+	interns, releases int
+}
+
+func (ti *testInterner) Intern(s string) string {
+	ti.mut.Lock()
+	defer ti.mut.Unlock()
+
+	ti.refs[s]++
+	ti.interns++
+
+	return s
+}
+
+func (ti *testInterner) Release(s string) {
+	ti.mut.Lock()
+	defer ti.mut.Unlock()
+	ti.refs[s]--
+	ti.releases++
+}
+
+func BenchmarkStringInterner(b *testing.B) {
+	var (
+		r       = rand.New(rand.NewSource(1))
+		scraper = &testScraper{}
+		cache   = newScrapeCache(intern.New(prometheus.NewRegistry()))
+	)
+
+	sl := newScrapeLoop(context.Background(),
+		scraper,
+		nil, nil,
+		nopMutator,
+		nopMutator,
+		func(ctx context.Context) storage.Appender { return &collectResultAppender{} },
+		cache,
+		0,
+		true,
+		nil,
+	)
+
+	buf := bytes.NewBuffer(nil)
+
+	// First step: generate fake metrics and write them out.
+	{
+		b.StopTimer()
+
+		// Create a set of fake metrics with 5 labels each
+		reg := prometheus.NewRegistry()
+		for i := 0; i < 1_000_000; i++ {
+			lbls := prometheus.Labels{}
+			for j := 0; j < 5; j++ {
+				lbls[randStringRunes(r, 6)] = randStringRunes(r, 6)
+			}
+
+			c := prometheus.NewCounter(prometheus.CounterOpts{
+				Name:        randStringRunes(r, 20),
+				ConstLabels: lbls,
+			})
+			c.Inc()
+
+			reg.MustRegister(c)
+		}
+
+		// Write it out.
+		enc := expfmt.NewEncoder(buf, expfmt.FmtText)
+		mfs, err := reg.Gather()
+		require.NoError(b, err)
+		for _, mf := range mfs {
+			require.NoError(b, enc.Encode(mf))
+		}
+
+		b.StartTimer()
+	}
+
+	for n := 0; n < b.N; n++ {
+		slApp := sl.appender(context.Background())
+		_, _, _, err := sl.append(slApp, buf.Bytes(), string(expfmt.FmtText), time.Now())
+		require.NoError(b, err)
+	}
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randStringRunes(r *rand.Rand, n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[r.Intn(len(letterRunes))]
+	}
+	return string(b)
 }


### PR DESCRIPTION
Ensures that interning and releasing strings are done in sync with the cache being manipulated to prevent duplicate interned references from being created. 

Adds a metric to track how many interned strings exist to detect leaks. Also adds tests and a benchmark to keep track of this more easily. 

```
name              old time/op    new time/op    delta
StringInterner-8     4.23s ± 0%     2.39s ± 0%  -43.51%

name              old alloc/op   new alloc/op   delta
StringInterner-8     421MB ± 0%     418MB ± 0%   -0.73%

name              old allocs/op  new allocs/op  delta
StringInterner-8     4.41M ± 0%     4.41M ± 0%   -0.00%
```