### PR TITLE
Hackathon: remote write aware of being secondary replica

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -191,6 +191,9 @@ var (
 		// Backoff times for retrying a batch of samples on recoverable errors.
 		MinBackoff: model.Duration(30 * time.Millisecond),
 		MaxBackoff: model.Duration(5 * time.Second),
+
+		SecondaryReplicaFallBehindDuration:  model.Duration(time.Minute),
+		SecondaryReplicaFallBehindThreshold: model.Duration(time.Second),
 	}
 
 	// DefaultMetadataConfig is the default metadata configuration for a remote write endpoint.
@@ -880,6 +883,10 @@ type QueueConfig struct {
 	MinBackoff       model.Duration `yaml:"min_backoff,omitempty"`
 	MaxBackoff       model.Duration `yaml:"max_backoff,omitempty"`
 	RetryOnRateLimit bool           `yaml:"retry_on_http_429,omitempty"`
+
+	// Secondary replica config
+	SecondaryReplicaFallBehindDuration  model.Duration `yaml:"secondary_replica_fall_behind_duration"`
+	SecondaryReplicaFallBehindThreshold model.Duration `yaml:"secondary_replica_fall_behind_threshold"`
 }
 
 // MetadataConfig is the configuration for sending metadata to remote

--- a/config/config.go
+++ b/config/config.go
@@ -191,9 +191,6 @@ var (
 		// Backoff times for retrying a batch of samples on recoverable errors.
 		MinBackoff: model.Duration(30 * time.Millisecond),
 		MaxBackoff: model.Duration(5 * time.Second),
-
-		SecondaryReplicaFallBehindDuration:  model.Duration(time.Minute),
-		SecondaryReplicaFallBehindThreshold: model.Duration(time.Second),
 	}
 
 	// DefaultMetadataConfig is the default metadata configuration for a remote write endpoint.
@@ -883,10 +880,6 @@ type QueueConfig struct {
 	MinBackoff       model.Duration `yaml:"min_backoff,omitempty"`
 	MaxBackoff       model.Duration `yaml:"max_backoff,omitempty"`
 	RetryOnRateLimit bool           `yaml:"retry_on_http_429,omitempty"`
-
-	// Secondary replica config
-	SecondaryReplicaFallBehindDuration  model.Duration `yaml:"secondary_replica_fall_behind_duration"`
-	SecondaryReplicaFallBehindThreshold model.Duration `yaml:"secondary_replica_fall_behind_threshold"`
 }
 
 // MetadataConfig is the configuration for sending metadata to remote

--- a/model/intern/intern.go
+++ b/model/intern/intern.go
@@ -29,7 +29,7 @@ import (
 
 // Shared interner
 var (
-	Global Interner = New(prometheus.DefaultRegisterer)
+	Global = New(prometheus.DefaultRegisterer)
 )
 
 // Interner is a string interner.

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -354,7 +354,7 @@ func TestMetricTypeToMetricTypeProto(t *testing.T) {
 }
 
 func TestDecodeWriteRequest(t *testing.T) {
-	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
+	buf, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 
 	actual, err := DecodeWriteRequest(bytes.NewReader(buf))

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -541,7 +541,7 @@ func (t *QueueManager) updateSecondaryReplica(isSecondary bool) (changed bool) {
 	changed = t.isSecondaryReplica.Swap(isSecondary) != isSecondary
 
 	if changed {
-		level.Debug(t.logger).Log("QueueManager.updateSecondaryReplica", "is_secondary", isSecondary)
+		level.Info(t.logger).Log("QueueManager.updateSecondaryReplica", "is_secondary", isSecondary)
 		if isSecondary {
 			t.metrics.isSecondaryReplica.Set(1)
 		} else {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -542,7 +542,7 @@ func (t *QueueManager) updateSecondaryReplica(isSecondary bool) {
 	changed := t.isSecondaryReplica.Swap(isSecondary) != isSecondary
 
 	if changed {
-		level.Info(t.logger).Log("QueueManager.updateSecondaryReplica", "is_secondary", isSecondary)
+		level.Info(t.logger).Log("msg", "QueueManager.updateSecondaryReplica", "is_secondary", isSecondary)
 		if isSecondary {
 			t.metrics.isSecondaryReplica.Set(1)
 		} else {

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -1509,6 +1509,7 @@ func (s *shards) sendSamplesWithBackoff(ctx context.Context, samples []prompb.Ti
 		}
 
 		if s.qm.updateSecondaryReplica(wf.IsSecondaryReplica) {
+			isSecondary = wf.IsSecondaryReplica
 			span.SetAttributes(attribute.Bool("new_is_secondary", wf.IsSecondaryReplica))
 			if !wf.IsSecondaryReplica {
 				req, err = buildWriteRequest(samples, nil, pBuf, *buf)

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -347,6 +347,7 @@ func (m *queueManagerMetrics) register() {
 			m.sentBytesTotal,
 			m.metadataBytesTotal,
 			m.maxSamplesPerSend,
+			m.isSecondaryReplica,
 		)
 	}
 }

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestRemoteWriteHandler(t *testing.T) {
-	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
+	buf, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("", "", bytes.NewReader(buf))
@@ -74,7 +74,7 @@ func TestRemoteWriteHandler(t *testing.T) {
 }
 
 func TestOutOfOrderSample(t *testing.T) {
-	buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
+	buf, err := buildWriteRequest([]prompb.TimeSeries{{
 		Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric"}},
 		Samples: []prompb.Sample{{Value: 1, Timestamp: 0}},
 	}}, nil, nil, nil)
@@ -99,7 +99,7 @@ func TestOutOfOrderSample(t *testing.T) {
 // don't fail on ingestion errors since the exemplar storage is
 // still experimental.
 func TestOutOfOrderExemplar(t *testing.T) {
-	buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
+	buf, err := buildWriteRequest([]prompb.TimeSeries{{
 		Labels:    []prompb.Label{{Name: "__name__", Value: "test_metric"}},
 		Exemplars: []prompb.Exemplar{{Labels: []prompb.Label{{Name: "foo", Value: "bar"}}, Value: 1, Timestamp: 0}},
 	}}, nil, nil, nil)
@@ -122,7 +122,7 @@ func TestOutOfOrderExemplar(t *testing.T) {
 }
 
 func TestOutOfOrderHistogram(t *testing.T) {
-	buf, _, err := buildWriteRequest([]prompb.TimeSeries{{
+	buf, err := buildWriteRequest([]prompb.TimeSeries{{
 		Labels:     []prompb.Label{{Name: "__name__", Value: "test_metric"}},
 		Histograms: []prompb.Histogram{HistogramToHistogramProto(0, &testHistogram)},
 	}}, nil, nil, nil)
@@ -144,7 +144,7 @@ func TestOutOfOrderHistogram(t *testing.T) {
 }
 
 func TestCommitErr(t *testing.T) {
-	buf, _, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
+	buf, err := buildWriteRequest(writeRequestFixture.Timeseries, nil, nil, nil)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("", "", bytes.NewReader(buf))


### PR DESCRIPTION
This implements write feedback from the remote write endpoint, telling the caller that it's now the secondary replica, which makes it send empty requests instead of actually encoding samples, reducing bandwidth and CPU usage.