### PR TITLE
fix(write_handler): fix duplicate metrics registration panic

### DIFF
--- a/storage/remote/write_handler.go
+++ b/storage/remote/write_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 	otlptranslator "github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite"
+	util "github.com/prometheus/prometheus/util/metrics"
 )
 
 type writeHandler struct {
@@ -52,7 +53,7 @@ func NewWriteHandler(logger log.Logger, reg prometheus.Registerer, appendable st
 		}),
 	}
 	if reg != nil {
-		reg.MustRegister(h.samplesWithInvalidLabelsTotal)
+		h.samplesWithInvalidLabelsTotal = util.MustRegisterOrGet(reg, h.samplesWithInvalidLabelsTotal).(prometheus.Counter)
 	}
 	return h
 }

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -1,0 +1,16 @@
+package util
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// MustRegisterOrGet will attempt to register the supplied collector into the register. If it's already
+// registered, it will return that one.
+// In case that the register procedure fails with something other than already registered, this will panic.
+func MustRegisterOrGet(reg prometheus.Registerer, c prometheus.Collector) prometheus.Collector {
+	if err := reg.Register(c); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return are.ExistingCollector
+		}
+		panic(err)
+	}
+	return c
+}


### PR DESCRIPTION
<!--
    Don't forget!
    
    - If the PR adds or changes a behaviour or fixes a bug of an exported API it would need a unit/e2e test.
    
    - Where possible use only exported APIs for tests to simplify the review and make it as close as possible to an actual library usage.
    
    - No tests are needed for internal implementation changes.
    
    - Performance improvements would need a benchmark test to prove it.
    
    - All exposed objects should have a comment.
    
    - All comments should start with a capital letter and end with a full stop.
 -->
 
 Potentially closes https://github.com/grafana/agent/issues/6548 when PR got merged and upgraded in linked project's `go.mod`
 
 Fixes another infamous case of `duplicate metrics registration` panic. This time it's on `write_handler`
 
 - [x] Unit test added