### PR TITLE
reduce locking in disable staleness logic

### DIFF
--- a/scrape/manager.go
+++ b/scrape/manager.go
@@ -378,9 +378,12 @@ func (m *Manager) DisableEndOfRunStalenessMarkers(targetSet string, targets []*T
 		return
 	}
 
+	// Only hold the lock to find the scrape pool
 	m.mtxScrape.Lock()
-	defer m.mtxScrape.Unlock()
-	if pool, ok := m.scrapePools[targetSet]; ok {
-		pool.disableEndOfRunStalenessMarkers(targets)
+	sp, ok := m.scrapePools[targetSet]
+	m.mtxScrape.Unlock()
+
+	if ok {
+		sp.disableEndOfRunStalenessMarkers(targets)
 	}
 }

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -595,20 +595,12 @@ func (sp *scrapePool) refreshTargetLimitErr() error {
 }
 
 func (sp *scrapePool) disableEndOfRunStalenessMarkers(targets []*Target) {
-	loops := make([]loop, 0, len(targets))
-
-	// First find all the loops to minimise locking time
 	sp.mtx.Lock()
-	for _, t := range targets {
-		if l, ok := sp.loops[t.hash()]; ok {
-			loops = append(loops, l)
+	defer sp.mtx.Unlock()
+	for i := range targets {
+		if l, ok := sp.loops[targets[i].hash()]; ok {
+			l.disableEndOfRunStalenessMarkers()
 		}
-	}
-	sp.mtx.Unlock()
-
-	// Disable end of run staleness for loops we found.
-	for _, l := range loops {
-		l.disableEndOfRunStalenessMarkers()
 	}
 }
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -595,12 +595,20 @@ func (sp *scrapePool) refreshTargetLimitErr() error {
 }
 
 func (sp *scrapePool) disableEndOfRunStalenessMarkers(targets []*Target) {
+	loops := make([]loop, 0, len(targets))
+
+	// First find all the loops to minimise locking time
 	sp.mtx.Lock()
-	defer sp.mtx.Unlock()
-	for i := range targets {
-		if l, ok := sp.loops[targets[i].hash()]; ok {
-			l.disableEndOfRunStalenessMarkers()
+	for _, t := range targets {
+		if l, ok := sp.loops[t.hash()]; ok {
+			loops = append(loops, l)
 		}
+	}
+	sp.mtx.Unlock()
+
+	// Disable end of run staleness for loops we found.
+	for _, l := range loops {
+		l.disableEndOfRunStalenessMarkers()
 	}
 }
 


### PR DESCRIPTION
This came up in profiles again. Holding the Manager lock especially is very bad for Alloy's use case. In this PR I further reduce the time we hold the locks for when disabling staleness.
```
go test ./scrape/...
ok  	github.com/prometheus/prometheus/scrape	31.794s
```
